### PR TITLE
Add basic shell tracing support

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -36,7 +36,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Note we globally ignore SC2148 as a lot of this shell is library
           # only not something that should have a shebang line.
-          SHELLCHECK_OPTS: --severity=warning --color=always -e SC2148 # We can globally ignore things here if we want with -e SC1234
+          #
+          # The shebang check is disabled as most of the shell here is truly a
+          # library and these scripts cannot be ran, we default to posix shell
+          # SC2148
+          #
+          # We also allow local to be used for scoping with variables SC3043
+          SHELLCHECK_OPTS: --shell=sh --severity=warning --color=always -e SC2148 -e SC3043
+          # Options kinda chosen at random based off most of our shell in use
+          # these seemed to be the union set of most of them.
           SHFMT_OPTS: -ci -p -i 2 -bn -sr
         with:
           sh_checker_comment: true

--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -46,16 +46,25 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Run shellspec
         run: |
-          nix-shell -p shellspec --run 'shellspec'
+          sudo apt-get install -y ksh zsh make curl
+          VERSION=0.28.1
+          (
+            install -dm755 $HOME/shellspec
+            cd $HOME/shellspec
+            curl -L https://github.com/shellspec/shellspec/archive/${VERSION}.tar.gz -o shellspec-${VERSION}.tar.gz
+            tar xzvf shellspec-${VERSION}.tar.gz
+            sudo ln -s $HOME/shellspec/shellspec-${VERSION}/shellspec /usr/bin/shellspec
+          )
+          make test-all SHELLSPECARGS="--jobs 2 --random specfiles"
 
       - if: ${{ matrix.os == 'macos-latest' }}
         name: Install shellspec (macOS)
         run: |
           brew tap shellspec/shellspec
           brew update
-          brew install shellspec ksh93 bash
+          brew install shellspec bash
 
       - if: ${{ matrix.os == 'macos-latest' }}
         name: Run shellspec
         run: |
-          shellspec --jobs 2 --random specfiles
+          make test-all SHELLSPECARGS="--jobs 2 --random specfiles"

--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -46,6 +46,7 @@ jobs:
       - if: ${{ matrix.os == 'ubuntu-latest' }}
         name: Install shellspec (ubuntu)
         run: |
+          sudo apt-get update
           sudo apt-get install -y ksh zsh make curl
           VERSION=0.28.1
           install -dm755 $HOME/shellspec
@@ -63,4 +64,4 @@ jobs:
 
       - name: Run shellspec
         run: |
-          make test-all SHELLSPECARGS="--jobs 2 --random specfiles"
+          make test-all SHELLSPECARGS="--jobs 2 --random specfiles" || make test-all SHELLSPECARGS="-x"

--- a/.github/workflows/shellspec.yml
+++ b/.github/workflows/shellspec.yml
@@ -44,18 +44,15 @@ jobs:
             experimental-features = nix-command flakes
 
       - if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: Run shellspec
+        name: Install shellspec (ubuntu)
         run: |
           sudo apt-get install -y ksh zsh make curl
           VERSION=0.28.1
-          (
-            install -dm755 $HOME/shellspec
-            cd $HOME/shellspec
-            curl -L https://github.com/shellspec/shellspec/archive/${VERSION}.tar.gz -o shellspec-${VERSION}.tar.gz
-            tar xzvf shellspec-${VERSION}.tar.gz
-            sudo ln -s $HOME/shellspec/shellspec-${VERSION}/shellspec /usr/bin/shellspec
-          )
-          make test-all SHELLSPECARGS="--jobs 2 --random specfiles"
+          install -dm755 $HOME/shellspec
+          cd $HOME/shellspec
+          curl -L https://github.com/shellspec/shellspec/archive/${VERSION}.tar.gz -o shellspec-${VERSION}.tar.gz
+          tar xzvf shellspec-${VERSION}.tar.gz
+          sudo ln -s $HOME/shellspec/shellspec-${VERSION}/shellspec /usr/bin/shellspec
 
       - if: ${{ matrix.os == 'macos-latest' }}
         name: Install shellspec (macOS)
@@ -64,7 +61,6 @@ jobs:
           brew update
           brew install shellspec bash
 
-      - if: ${{ matrix.os == 'macos-latest' }}
-        name: Run shellspec
+      - name: Run shellspec
         run: |
           make test-all SHELLSPECARGS="--jobs 2 --random specfiles"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -57,7 +57,8 @@ ENTR:=entr
 SH:=sh
 BASH:=bash
 KSH:=ksh
-SHELLS:=$(SH) $(BASH) $(KSH)
+ZSH:=zsh
+SHELLS:=$(SH) $(BASH) $(KSH) $(ZSH)
 DATE:=date
 
 SPEC_FILE ?= ${NAME}.spec

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,7 +52,7 @@ endif
 # Might want to run with parallelism by default to make sure people don't
 # introduce dependencies in tests and with randomness.
 # SHELLSEPCARGS:=--jobs 4
-SHELLSEPCARGS:=
+SHELLSPECARGS:=
 ENTR:=entr
 SH:=sh
 BASH:=bash
@@ -66,13 +66,17 @@ SOURCE_NAME ?= ${NAME}
 BUILD_DIR ?= $(PWD)/dist/rpmbuild
 SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}-${VERSION}.tar.bz2
 
+phonies:=ci
+phonies+=test
+phonies+=test-all
+
+.PHONY: $(phonies)
+
 # Quick run shellspec to do a one off test
-.PHONY: test
 test:
 	$(SHELLSPEC)
 
 # Run tests against all the shell intepreters in SHELLS
-.PHONY: test-all
 test-all:
 	set -xe; for s in $(SHELLS); do $(SHELLSPEC) --shell $$s $(SHELLSPECARGS); done;
 
@@ -82,9 +86,8 @@ test-all:
 # Good shell shouldn't care what bourne interpreter its running within and
 # ensures we can run in a busybox/alpine linux container easy peasy lemon
 # squeezy if needed.
-.PHONY: ci
 ci:
-	find . -name "*.sh" -type f | $(ENTR) -d sh -xec "for s in $(SHELLS); do $(SHELLSPEC) --shell \$$s $(SHELLSPECARGS); done; $(DATE)"
+	find . -name "*.sh" -type f | $(ENTR) -d sh -xec "shellcheck --shell=sh; for s in $(SHELLS); do $(SHELLSPEC) --shell \$$s $(SHELLSPECARGS); done; $(DATE)"
 
 .PHONY: rpm
 rpm: prepare rpm_package_source rpm_build_source rpm_build

--- a/examples/README.adoc
+++ b/examples/README.adoc
@@ -9,7 +9,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-== `cmdhook.sh`
+== `cmd.sh`
 
 This example script exists to demonstrate how a user could write their own hooks that could be called via the `cmdhook` wrapper generation function.
 

--- a/examples/cmd.sh
+++ b/examples/cmd.sh
@@ -33,14 +33,6 @@ if [ -n "${DEBUG}" ]; then
   #shellcheck source=./../sh/lib.sh
   . "${SOURCEPREFIX}/lib.sh"
 
-  # Not used directly but indirectly so shellchecks just being pedantic.
-  #shellcheck disable=SC2034
-  DEFAULTPOSTHOOK="${DEFAULTPOSTHOOK:-defaultposthook}"
-
-  # We don't want word splitting here with this var.
-  #shellcheck disable=SC2086
-  wrapcmd ${WRAP:-curl jq ls rm}
-
   posthook() {
     rc="${1}"
     shift
@@ -76,6 +68,10 @@ EOF
     RMPOSTHOOK="${RMPOSTHOOK:-posthook}"
     LSPOSTHOOK="${LSPOSTHOOK:-posthook}"
   }
+
+  # We don't want word splitting here with this var.
+  #shellcheck disable=SC2086
+  wrapcmd ${WRAP:-curl jq ls rm}
 fi
 
 # Needs to be below the ${DEBUG} block as that would count as an unbound variable if it is not set
@@ -85,7 +81,9 @@ fi
 # The "actual" script, note you could skip defining your own hook to save some
 # lines but this is a complete example.
 curl uri://isinvalid | jq -r .
-curl -s https://example.com/dne | jq -r .
+jq -r . << EOF
+this is not json
+EOF
 
 ls /does/not/exist
 rm /does/not/exist

--- a/examples/trace.sh
+++ b/examples/trace.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+#-*-mode: Shell-script; coding: utf-8;-*-
+_base=$(basename "$0")
+_dir=$(cd -P -- "$(dirname -- "$(command -v -- "$0")")" && pwd -P || exit 126)
+export _base _dir
+
+#shellcheck source=./../sh/lib.sh
+#shellcheck disable=SC2086,SC2046
+. ${SOURCEPREFIX:=$(dirname $(readlink -f "${_dir}/../sh/lib.sh"))}/lib.sh
+tracing_enabled && enable_tracing "${_base}" jq ls curl grep ps
+
+# warn() { printf "warning! $*\n" >&2; }
+# info() { printf "information! $*\n" >&2; }
+# debug() { printf "debug! $*\n" >&2; }
+
+jq -r . << EOF
+this is not json
+EOF
+
+ls /does/not/exist
+
+# emerg "red alert!"
+warn "This goes to the screen and to the trace file if enabled"
+curl http://example.com/dne | jq -r . &
+sleep 1 &
+info "This only goes to the trace file by default"
+debug "Debug also only goes to the trace file by default"
+
+wait
+
+debug "fin"

--- a/sh/README.adoc
+++ b/sh/README.adoc
@@ -9,43 +9,56 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-== Rough design plan
+== Goals
 
-CAUTION: Not yet fully implemented.
+To help facilitate bourne shell debugging. Note, this means bourne, not only bourne again shell. This library is enforced to be posix clean and all unit tests are run against all known bourne shells. This is to ensure the library is usable in shells such as busybox sh, ash, or dash. The goal is for this shell library to be usable in and out of environments such as rescue shells etc...
 
-Premise here is if you want the whole hog just source `sh/lib.sh` after setting `SOURCEPREFIX` to the directory containing
-that dir/file. For POSIX, shells there is no portable way to "know" where one imported from, so we just defer that to calling
-scripts as they can know where they're importing from.
+While we don't hate c family shells, given their limited usage, this library will not ever support them without support from shellspec.
 
-When you have that you get all the fun stuff.
+Hidden design goals to the library is to make incorporation of debugging facilities contained within as easy as possible. As well as to create a "standard" xkcd stdlib with known contract behavior that can be built on top of.
 
-Goal(s):
+== Portability Caveats
 
-* Make debugging shell a bit easier and have some standard library of shell aiding
-* Promote defensive scripting; provide common error handling and helper functions to mitigate mistakes
+While the general goal is posix clean, given it is 2023 and all the shells being tested allow for it. Using local to namespace vars in functions is recommended to prevent variable name collisions.
 
-That will end up with something like scripts having:
+Taking inspiration from c++ and its ilk any variable prefixed with _ should be considered to be an implementation detail. Using any variable with these variables should be done at the callers understanding they may entirely change or be removed in any future library update.
+
+== Porting Script Howto
+
+All that is well and good but how do you actually use the library? The library assumes you know where you're importing it from, aka where it resides on disk is a known factor.
+
+That will end up with existing or new scripts starting with something like the following:
 
 [source,sh]
 ----
-SOURCEPREFIX=$(pwd)/sh
-. ${SOURCEPREFIX}/lib.sh
+#shellcheck disable=SC2086,SC2046
+. ${SOURCEPREFIX:=$(dirname $(readlink -f "${_dir}/path/to/sh/lib.sh"))}/lib.sh
+tracing_enabled && enable_tracing "${_base}" jq ls curl grep ps
 
-wrapcmd ls ps curl jq
-
-... stuff
+... your script goes here and uses those commands or other to be wrapped at runtime
 ----
 
-When called with `DEBUG=anyvalue` and/or `TIMELINE=anyvalue` one will end up with a directory of 
-`/tmp/PARENTPID` with directories of the epoch start time of any `ls`, `ps`, `curl` or `jq` call containing:
+And when called with *DEBUG=trace* you will end up with a txz of the run printed to stderr at the end of the script run containing all the wrapped commands stdin, stderr, and stdout streams.
 
-* `cmdline`: The command line of what was called
-* `rc`: The return code it exited with
-* `stdin{-is-a-pipe}`: Standard input, and if it was a pipe the filename will reflect that
-* `stdout{-is-a-pipe}`: Standard output, and if it was a pipe the filename will reflect that
-* `stderr{-is-a-pipe}`: Standard error, and if it was a pipe the filename will reflect that
+Please stick to the SOURCEPREFIX line above even if it is crazy, the intent is to make it easy to point any script using this library to another install via:
 
-That will help with debugging shell scripts that utilize the wrapper functions.
+[source,sh]
+----
+SOURCEPREFIX=/some/other/path/to/lib.sh script
+----
 
-In a near future commit default hooks for the wrapper functions generated will help in output to the screen.
-For now this is MVP status. An example hook is located in the examples directory at the base of https://github.com/Cray-HPE/libcsm[this repo].
+This lets us not have to modify scripts using this library but test out updates to the library easily.
+
+== Rough design goals
+
+Beyond "just write ye olde posix compliant shell", the underlying design goal was to demonstrate that you can indeed debug shell command inputs on stdin/stdout and provide a lot better development experience with copious abuse of eval() and company.
+
+While the techniques employed in this library are not one recommended for general shell usage they do enable a much better user and developer experience around debugging situations such as: why did that command I piped complain about data on stdin, and what exactly did it send?
+
+With the tracing support you also gain post run debug logging for later inspection a la crash etc...
+
+== Future additions for an adventurous or crazier person than me
+
+Might be useful to have the tracing functionality save wrapped command outputs that can be re-used as a unit test for the library to save time in adding more tests for other parts of the library.
+
+Figure out some way to not have to require callers to explicitly call wrapcmd() on the functions or commands desired to be traced/wrapped. This might be a bit hard or even impossible portably without something like precmd() in zsh in all shells. The current design while not great works decently enough. There might be something in the bowels of posix that might make this possible however.

--- a/sh/cmd.sh
+++ b/sh/cmd.sh
@@ -39,11 +39,6 @@
 # we prefix the command name with sut, e.g. wrapcmd foo will result in a
 # trampoline function of sutfoo not foo. This is to enable shellspec
 # itself to be able to unit test the trampoline setup function below.
-#
-# Future enhancements will set this up to write stuff out to a timeline
-# directory of wrapped commands, return codes, stdin/out/err as files.
-#
-# That is a future me task.
 wrapcmd() {
   # Bit of a cheat to ensure if we're run under set -u we can detect things.
   # We only do this if DEBUG is set to... whatever doesn't matter the value.
@@ -85,10 +80,27 @@ wrapcmd() {
 
     # I had to do evil with the eval above...
     #shellcheck disable=SC2154
-    if [ "${posthook}" != "" ]; then
+    if [ -n "${posthook}" ]; then
       eval "${UPOST}=\$${UPOST}"
-    elif [ "${defposthook}" != "" ]; then
+    elif [ -n "${defposthook}" ]; then
       eval "${UPOST}=\${DEFAULTPOSTHOOK}"
+    fi
+
+    # Used by the tracing features to copy stdin/out/err to the trace directory.
+    # Not intended for users/script callers.
+    TPOST="${uppername}TRACEHOOK"
+
+    # This is a huge hack future me red/green/refactor it.
+    #shellcheck disable=SC2116 disable=SC2086
+    eval "tracehook=\$${TPOST}"
+    deftracehook="${DEFAULTTRACEHOOK}"
+
+    # I had to do evil with the eval above...
+    #shellcheck disable=SC2154
+    if [ -n "${tracehook}" ]; then
+      eval "${TPOST}=\$${TPOST}"
+    elif [ -n "${deftracehook}" ]; then
+      eval "${TPOST}=\${DEFAULTTRACEHOOK}"
     fi
 
     # TODO: pre/validate default hooks? Not sure that makes sense... Easy to add
@@ -162,6 +174,13 @@ ${cmd}posthook() {
   [ -n \"\$${UPOST}\" ] && \$${UPOST} \$@ || :;
 }"
 
+    # Trace hook eval's like the user hooks
+    eval "${TPOST}=\${${TPOST}-}"
+    eval "
+${cmd}tracehook() {
+  [ -n \"\$${TPOST}\" ] && \$${TPOST} \$@ || :;
+}"
+
     # I want to be clear, this entire things crazy enough as it is but this eval
     # is not for the faint of heart, here there definitely be dragons, hold onto
     # your butts.
@@ -209,6 +228,10 @@ ${cmdname}() {
   cat \$stderr >&2
 
   ${cmd}posthook \$rc \$stdin \$stdout \$stderr ${evalcmd} \"\$@\"
+
+  # Tracing hook comes after everything else, here to allow saving relevant data
+  # future work may have a pre trace hook too or not depends on use cases.
+  ${cmd}tracehook \$rc \$stdin \$stdout \$stderr ${evalcmd} \"\$@\"
   return \$rc
 }"
   done
@@ -269,4 +292,190 @@ stderr ${stderrpre-}$(_dump ${stderr})${reset-}
 
 ${yellow-}default cmdhook debug end${reset-}
 EOF
+}
+
+# Default tracing hook. (ab)uses the knowledge that TRACEPREFIX when tracing is
+# enabled is not null.
+defaulttracehook() {
+  if [ -n "${TRACEPREFIX}" ]; then
+    install -dm755 "${TRACEPREFIX}"
+
+    _defaulttracehook_rc="${1}"
+    shift
+    _defaulttracehook_stdin="${1}"
+    shift
+    _defaulttracehook_stdout="${1}"
+    shift
+    _defaulttracehook_stderr="${1}"
+    shift
+
+    # LC_ALL=C here so macos tr gets out of utf8 mode
+    _defaulttracehook_epoch="$(date +%s)-$(LC_ALL=C tr -dc A-Za-z0-9 < /dev/urandom | head -c 8)"
+    _defaulttracehook_cmds="${TRACEPREFIX}/cmd"
+    _defaulttracehook_date="${_defaulttracehook_cmds}/${_defaulttracehook_epoch}"
+    install -dm755 "${_defaulttracehook_date}"
+
+    # Preserve the filename of stdin-is-a-pipe to denote if that fd was a pipe
+    # or not.
+    for file in "${_defaulttracehook_stdin}" "${_defaulttracehook_stdout}" "${_defaulttracehook_stderr}"; do
+      # Not an issue for this, these files never have spaces in them.
+      #shellcheck disable=SC2046
+      filename=$(basename $(realpath "${file}") | head -c-10)
+      install -m444 "${file}" "${_defaulttracehook_date}/${filename}"
+    done
+
+    #shellcheck disable=SC2086
+    cat << EOF > "${_defaulttracehook_date}/info"
+wrapcmd tracing data
+
+command: $@
+rc: $_defaulttracehook_rc
+pwd: $(pwd)
+EOF
+
+    cat << EOF >> "${TRACEPREFIX}/timeline"
+wrapcmd(${_defaulttracehook_epoch}): $@ rc(${_defaulttracehook_rc})
+EOF
+  fi
+}
+
+# When not under test we can set the default hooks
+if [ -z "${SUT}" ]; then
+  DEFAULTPOSTHOOK="${DEFAULTPOSTHOOK:-defaultposthook}"
+  DEFAULTTRACEHOOK="${DEFAULTTRACEHOOK:-defaulttracehook}"
+fi
+
+# Trace components below here
+
+# Default of where trace files get stored at script exit, can be set at runtime
+# elsewhere.
+TRACEDIR="${TRACEDIR:-${TMPDIR:-/tmp}/libcsm-trace}"
+
+# This is null by default, unless tracing is enabled in which case it will be
+# the scripts trace dir. Used by other functions/hooks.
+TRACEPREFIX=
+
+# Make calling scripts consistent with enabling tracing support
+tracing_enabled() {
+  [ -n "${DEBUG}" ] && [ "trace" = "${DEBUG}" ]
+}
+
+# Wrapper around install to create our trace dir if its missing
+_mktracedirs() {
+  for d in "${TRACEDIR}" ${_enable_tracing_script} "${_enable_tracing_script}/${_enable_tracing_subdir}"; do
+    install -dm755 "${TRACEDIR}/${d}"
+  done
+}
+
+# Here to make unit testing simpler
+_epoch() { date +%s; }
+_pwd() { pwd; }
+_tty() { tty; }
+_who() { who; }
+
+# This is a hack because of how shellspec eval()'s things. Can't depend on $ENV
+# vars exactly the way you want.
+#
+# So just let the default be what we'd want, but in the unit tests we redefine
+# this function.
+_trace_cleanup() {
+  return 0
+}
+
+# Scripts opt into tracing features or not
+# Side effect of call:
+# - will create a dir $TRACEDIR/NAME/$(date +%s) that holds all the tracing output
+# - will create a file timeline in ^^^ that contains basic runtime information/data (what all to collect?)
+#
+# First arg is the breadcrumb of what is being traced, normally the script name
+# itself. The rest of the args to enable tracing are the commands to be traced.
+enable_tracing() {
+  _enable_tracing_script="${1?}"
+  shift > /dev/null 2>&1 || :
+
+  wrapped=${WRAP:-$@}
+
+  # Let $WRAP be the runtime var any user can use to override what is wrapped.
+  #shellcheck disable=SC2086
+  [ -n "$*" ] && wrapcmd ${wrapped}
+
+  # Overrideable to allow for easier unit testing
+  _enable_tracing_subdir="$(_epoch)"
+
+  _mktracedirs
+
+  _enable_tracing_prefix="${TRACEDIR}/${_enable_tracing_script}/${_enable_tracing_subdir}"
+  _enable_tracing_timeline="${_enable_tracing_prefix}/timeline"
+
+  export TRACEPREFIX="${_enable_tracing_prefix}"
+
+  env > "${_enable_tracing_prefix}/env"
+  uptime > "${_enable_tracing_prefix}/uptime"
+  ps -ef > "${_enable_tracing_prefix}/ps-ef"
+
+  install -m644 /dev/null "${_enable_tracing_timeline}"
+
+  # Note: this isn't a multiline here doc as shellspec will eval() this shell
+  # and believe it or not, thats when the > gets evaluated. So be careful using
+  # cat > file << FIN if file is in a directory that will only exist at run time.
+  printf "trace enabled at %s for %s\nargs:%s\npwd: %s\ntty: %s\nwho: %s\nstart: %s\n" "${_enable_tracing_subdir}" "${_enable_tracing_script}" "${wrapped}" "$(_pwd)" "$(_tty)" "$(_who)" "$(_epoch)" > "${_enable_tracing_timeline}"
+
+  # For unit testing we need to not do cleanup through the hook
+  if _trace_cleanup; then
+    trap tracing_cleanup_hook EXIT
+  fi
+}
+
+# The hook calls this and the unit tests do as well.
+_clean_trace_dir() {
+  # Cleanup the uncompressed dir the txz compressed to make sure we don't leave
+  # rabbit turds all over the filesystem.
+  rm -fr "${_enable_tracing_prefix}"
+  rmdir "${TRACEDIR}/${_enable_tracing_script}" > /dev/null 2>&1 || :
+}
+
+# Just tars up the entirety of the run for later perusal.
+_mktxz() {
+  txz="${1?_mktxz needs an arg for the txz file to be created bra}"
+
+  _tracing_cleanup_hook_txz="${_enable_tracing_prefix}.txz"
+
+  if cd "${_enable_tracing_prefix}"; then
+    tar -cJf "${txz}" "." > /dev/null 2>&1
+  else
+    return 1
+  fi
+}
+
+# Append to the timeline when the hook runs
+_mark_trace_done() {
+  _mktracedirs
+  cat >> "${_enable_tracing_timeline}" << EOF
+done: $(_epoch)
+EOF
+}
+
+# Responsible for cleaning up the directory storing all execution data and then
+# tarring up the dir and outputting that so users can clean it up or give it to
+# us for debugging.
+tracing_cleanup_hook() {
+  # Do not use -z here! Even if you want to, trust me.
+  if [ "${SUT}" != "" ]; then
+    _mark_trace_done
+
+    _tracing_cleanup_hook_txz="${_enable_tracing_prefix}.txz"
+
+    if _mktxz "${_tracing_cleanup_hook_txz}"; then
+      # Dump out the tracefile location to stderr for later perusal
+      # make this optional?
+      printf "tracefile: %s\n" "${_tracing_cleanup_hook_txz}" >&2
+
+      _clean_trace_dir
+    else
+      # This isn't output through the logger framework intentionally in the case
+      # of errors we just want to alert the user the tracing data is not
+      # available.
+      printf "warning: could not change to trace dir %s trace data not saved\n" "${_enable_tracing_prefix}" >&2
+    fi
+  fi
 }

--- a/sh/logger.sh
+++ b/sh/logger.sh
@@ -43,21 +43,32 @@
 # LVL     0     1     2    3     4    5      6    7
 SEVERITY="EMERG:ALERT:CRIT:ERROR:WARN:NOTICE:INFO:DEBUG"
 
-# Default log level is warn unless someone chooses a higher/lower level
+# Default log level is info unless someone chooses a higher/lower level
+# LOG_LEVEL=${LOG_LEVEL:-info}
 LOG_LEVEL=${LOG_LEVEL:-warn}
 
 # Basically get the index for the SEVERITY value, nothing special
+# TODO: The log severity won't change at runtime, turn this all into simple eval
+# statements that call static functions and save cpu O(n) time
 sevtolvl() {
   lvl=$1
-  sev=$(echo "${lvl}" | tr '[:lower:]' '[:upper:]')
-  idx=0
-  for s in $(echo $SEVERITY | tr ':' ' '); do
-    if [ "${sev}" = "${s}" ]; then
-      break
-    fi
-    idx=$((idx + 1))
-  done
-  return $idx
+  if ! command -v _memo_sevtolvl_"${lvl}" > /dev/null 2>&1; then
+    sev=$(echo "${lvl}" | tr '[:lower:]' '[:upper:]')
+    idx=0
+    for s in $(echo $SEVERITY | tr ':' ' '); do
+      if [ "${sev}" = "${s}" ]; then
+        break
+      fi
+      idx=$((idx + 1))
+    done
+
+    # The "memoize" logic here is simply define a function that returns the
+    # value. Unless we need to ever change logging levels dynamically at/during
+    # a script being run this is fine...
+    eval "_memo_sevtolvl_${lvl}() { return ${idx}; }"
+  fi
+
+  _memo_sevtolvl_"${lvl}"
 }
 
 # Print out ^^^
@@ -74,28 +85,35 @@ log_state() {
 # log error message with whatever
 # error message with whatever
 log() {
-  level=$1
+  _log_level=$1
   shift
 
-  sev=$(echo "${level}" | tr '[:lower:]' '[:upper:]')
-  lc=$(echo "${level}" | tr '[:upper:]' '[:lower:]')
+  _log_sev=$(echo "${_log_level}" | tr '[:lower:]' '[:upper:]')
+  _log_lc=$(echo "${_log_level}" | tr '[:upper:]' '[:lower:]')
 
-  sevtolvl "${sev}"
-  lhs=$?
+  sevtolvl "${_log_sev}"
+  _log_lhs=$?
   sevtolvl "${LOG_LEVEL}"
-  rhs=$?
-  if [ $lhs -le $rhs ]; then
+  _log_rhs=$?
+  if [ $_log_lhs -le $_log_rhs ]; then
     # Note: do not switch $* to $@ here, in spaces/args with printf lie dragons.
     # (it split lines probably off IFS dunno for now, future me problem)
     #
-    # For now dump to stderr
-    printf "%s: %s\n" "${lc}" "$*" >&2
+    # For now dump to stderr no control over what goes to stdout, use printf for that?
+    printf "%s: %s\n" "${_log_lc}" "$*" >&2
+  fi
+
+  if [ -n "${TRACEPREFIX}" ]; then
+    cat << EOF >> "${TRACEPREFIX}/timeline"
+${_log_lc}: $*
+EOF
   fi
 }
 
 # Helper functions for typing less log ... statements
 for lvl in emerg alert crit error warn notice info debug; do
   eval "
+_LOG_LEVEL_${lvl}=$(sevtolvl)
 ${lvl}() {
   log ${lvl} \"\$@\"
 }

--- a/sh/logger.sh
+++ b/sh/logger.sh
@@ -98,67 +98,14 @@ log() {
 }
 
 # Helper functions for typing less log ... statements
-emerg() {
-  log emerg "$@"
+for lvl in emerg alert crit error warn notice info debug; do
+  eval "
+${lvl}() {
+  log ${lvl} \"\$@\"
 }
 
-alert() {
-  log alert "$@"
+_${lvl}() {
+  LOG_LEVEL=${lvl} log ${lvl} \"\$@\"
 }
-
-crit() {
-  log crit "$@"
-}
-
-error() {
-  log error "$@"
-}
-
-warn() {
-  log warn "$@"
-}
-
-notice() {
-  log notice "$@"
-}
-
-info() {
-  log info "$@"
-}
-
-debug() {
-  log debug "$@"
-}
-
-# And more internal "ignore LOG_LEVEL" versions.
-_emerg() {
-  LOG_LEVEL=emerg log emerg "$@"
-}
-
-_alert() {
-  LOG_LEVEL=alert log alert "$@"
-}
-
-_crit() {
-  LOG_LEVEL=crit log crit "$@"
-}
-
-_error() {
-  LOG_LEVEL=error log error "$@"
-}
-
-_warn() {
-  LOG_LEVEL=warn log warn "$@"
-}
-
-_notice() {
-  LOG_LEVEL=notice log notice "$@"
-}
-
-_info() {
-  LOG_LEVEL=info log info "$@"
-}
-
-_debug() {
-  LOG_LEVEL=debug log debug "$@"
-}
+"
+done

--- a/sh/logger.sh
+++ b/sh/logger.sh
@@ -24,10 +24,6 @@
 #
 # Common logging library for posix shells.
 #
-# Note: on zsh you'll want to use emulate sh when importing as this depends on
-# the default word split behavior. I will fix zsh support at some point in the
-# future for now I doubt any zsh users but myself will care.
-#
 # Follow RFC 5424/syslog for log levels/behavior.
 #
 # Ref: https://datatracker.ietf.org/doc/html/rfc5424
@@ -45,7 +41,7 @@
 #    7       Debug              : debug-level messages
 
 # LVL     0     1     2    3     4    5      6    7
-SEVERITY="EMERG ALERT CRIT ERROR WARN NOTICE INFO DEBUG"
+SEVERITY="EMERG:ALERT:CRIT:ERROR:WARN:NOTICE:INFO:DEBUG"
 
 # Default log level is warn unless someone chooses a higher/lower level
 LOG_LEVEL=${LOG_LEVEL:-warn}
@@ -55,7 +51,7 @@ sevtolvl() {
   lvl=$1
   sev=$(echo "${lvl}" | tr '[:lower:]' '[:upper:]')
   idx=0
-  for s in $SEVERITY; do
+  for s in $(echo $SEVERITY | tr ':' ' '); do
     if [ "${sev}" = "${s}" ]; then
       break
     fi

--- a/spec/cmd_spec.sh
+++ b/spec/cmd_spec.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+#shellcheck disable=SC2317
+#
 # MIT License
 #
 # (C) Copyright 2023 Hewlett Packard Enterprise Development LP
@@ -170,6 +172,46 @@ stdout"
       The stdout should equal "stdout
 post"
       The stderr should equal "stderr"
+    End
+  End
+
+  Context 'enable_tracing() works as intended'
+    # To make these tests work we need to "change" time, since nothing acts on
+    # the time itself I'm just defining epoch date time to "sut"
+    _epoch() { printf "sut"; }
+    _pwd() { printf "sut"; }
+    _tty() { printf "sut"; }
+    _who() { printf "sut"; }
+
+    _trace_cleanup() { return 1; }
+
+    # For now just always tear down the trace directory should be fine even if
+    # its missing.
+    traceteardown() {
+      _clean_trace_dir
+    }
+    After 'traceteardown'
+
+    timelinecmp() {
+      %text
+      #|trace enabled at sut for sut.sh
+      #|args:
+      #|pwd: sut
+      #|tty: sut
+      #|who: sut
+      #|start: sut
+    }
+
+    It 'enable_tracing creates what we expect'
+      When call enable_tracing sut.sh
+      The status should equal 0
+      The path "${TRACEDIR}/sut.sh" should be a directory
+      The path "${TRACEDIR}/sut.sh/sut" should be a directory
+      The path "${TRACEDIR}/sut.sh/sut/timeline" should be a file
+      The path "${TRACEDIR}/sut.sh/sut/env" should be a file
+      The path "${TRACEDIR}/sut.sh/sut/ps-ef" should be a file
+      The path "${TRACEDIR}/sut.sh/sut/uptime" should be a file
+      The contents of file "${TRACEDIR}/sut.sh/sut/timeline" should equal "$(timelinecmp)"
     End
   End
 End


### PR DESCRIPTION
### Summary and Scope

For logging in argo and outside of it, I want to move our scripts to be able to save tracing data and any wrapped command data.

So what this implements is a single example for now, but it illustrates the intent behind the tracing.

If we run this new example, trace.sh without any vars set we get:

```
$ ./examples/trace.sh 
parse error: Invalid literal at line 1, column 5
ls: cannot access '/does/not/exist': No such file or directory
emerg: red alert!
warn: This goes to the screen and to the trace file if enabled
```

Boring and not at all useful, set -x is not much more help. But if we then set DEBUG=trace we get the following which for this example wraps jq and ls which are failing and intended to fail, and uses the logger in a trace fashion.

```
$ rm -fr {timeline,cmd}; DEBUG=trace ./examples/trace.sh
parse error: Invalid literal at line 1, column 5
default cmdhook debug begin

command: /Users/tishmack/.nix-profile/bin/jq -r .
rc: 4
pwd: /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library
stdin /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stdin-is-a-pipe-zTgTVA0Q:
this is not json
stdout /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stdout-Af56Zzdq: file is empty no data present
stderr /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stderr-67OnhInC:
parse error: Invalid literal at line 1, column 5

default cmdhook debug end
ls: cannot access '/does/not/exist': No such file or directory
default cmdhook debug begin

command: /Users/tishmack/.nix-profile/bin/ls /does/not/exist
rc: 2
pwd: /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library
stdin /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stdin-Id0ylW4S: file is empty no data present
stdout /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stdout-mQ59aYFk: file is empty no data present
stderr /private/var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T/csm-common-lib-88094/stderr-0mspOo4h:
ls: cannot access '/does/not/exist': No such file or directory

default cmdhook debug end
emerg: red alert!
warn: This goes to the screen and to the trace file if enabled
tracefile: /var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T//csm-common-trace/trace.sh/1669829270.txz
```

If we extract that txz file we get

```
$ tar xJvf /var/folders/pt/tg8xf0mx0j5_cp2m4hn_8qnc0000gn/T//csm-common-trace/trace.sh/1669828879.txz
x ./
x ./cmd/
x ./timeline
x ./cmd/1669828880-0IvkT37Q/
x ./cmd/1669828880-PUdwr5g8/
x ./cmd/1669828880-PUdwr5g8/stdout
x ./cmd/1669828880-PUdwr5g8/stderr
x ./cmd/1669828880-PUdwr5g8/stdin
x ./cmd/1669828880-PUdwr5g8/info
x ./cmd/1669828880-0IvkT37Q/stdout
x ./cmd/1669828880-0IvkT37Q/stderr
x ./cmd/1669828880-0IvkT37Q/info
x ./cmd/1669828880-0IvkT37Q/stdin-is-a-pipe
```

```
$ cat timeline
trace enabled at 1669828879 for trace.sh
cwd: /Users/tishmack/src/wrk/github.com/Cray-HPE/csm-common-library
tty: /dev/ttys008
who: tishmack console      2022-11-23 11:45
tishmack ttys000      2022-11-27 19:27
start: 1669828879
wrapcmd(1669828880-0IvkT37Q): /Users/tishmack/.nix-profile/bin/jq -r . rc(4)
wrapcmd(1669828880-PUdwr5g8): /Users/tishmack/.nix-profile/bin/ls /does/not/exist rc(2)
emerg: red alert!
warn: This goes to the screen and to the trace file if enabled
info: This only goes to the trace file by default
debug: Debug also only goes to the trace file by default
done: 1669828881
```

So we can see *all* logger wrapped messages, and wrapcmd wrapped commands and their rc. The specific dirs for each command is in the parens, and contains the stdin/err/out for each wrapped command.

We also get overall timing data of when things started e.g. the start: line and the done: lines respectively.
- Fixes:
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
