### PR TITLE
MTL-2071 Lock packages to Python

### DIFF
--- a/libcsm.spec
+++ b/libcsm.spec
@@ -37,6 +37,7 @@
 # python*-devel is not listed because our build environments install Python from source and not from OS packaging.
 BuildRequires: python-rpm-generators
 BuildRequires: python-rpm-macros
+Requires: %{python_version_nodots}-base
 Name: %(echo $NAME)
 BuildArch: %(echo $ARCH)
 License: MIT License
@@ -45,9 +46,9 @@ Version: %(echo $VERSION)
 Release: 1
 Source: %{name}-%{version}.tar.bz2
 Vendor: Hewlett Packard Enterprise Development LP
-Provides: python%{python_version_nodots}-%(echo $NAME) = %{version}-%{release}
-Provides: %(echo $NAME) = %{version}-%{release}
-%python_subpackages
+Provides: python%{python_version_nodots}-%{name} = %{version}-%{release}
+
+%{python_subpackages}
 
 %description
 A library for providing common functions to


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-2071

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This prevents installing `pythonX.Y-libcsm` on a system with a different Python version.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
