### PR TITLE
MTL-2076 Switch to virtualenv

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -1,0 +1,29 @@
+name: Promote a build to a release candidate
+on:
+  push:
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+a[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+b[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+rc[0-9]+'
+
+env:
+  ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+  ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+jobs:
+  Promote:
+    runs-on: ubuntu-latest
+    env:
+      HOME: /home/github-actions-runner
+    steps:
+
+      - uses: actions/checkout@v3
+
+      # TODO: Add step to wait and download the artifacts from Artifactory.
+      # NOTE: Russell is testing the logic to do this in another repository.
+
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+#          artifacts: ${{ env.dir_upload }}
+          prerelease: true
+          makeLatest: false

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,27 @@
+name: Promote build to a release (stable)
+on:
+  push:
+    tags:
+      - 'v?[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+  ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+jobs:
+  Promote:
+    runs-on: ubuntu-latest
+    env:
+      HOME: /home/github-actions-runner
+    steps:
+
+      - uses: actions/checkout@v3
+
+      # TODO: Add step to wait and download the artifacts from Artifactory.
+      # NOTE: Russell is testing the logic to do this in another repository.
+
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+#          artifacts: ${{ env.dir_upload }}
+          prerelease: false
+          makeLatest: true

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,7 +46,7 @@ endif
 export PYTHON_BIN := python$(PYTHON_VERSION)
 
 ifeq ($(VERSION),)
-export VERSION := $(shell python3 -m setuptools_scm | tr -s '-' '~' | tr -d '^v')
+export VERSION := $(shell python3 -m setuptools_scm | tr -s '-' '~' | sed 's/^v//')
 endif
 
 # Might want to run with parallelism by default to make sure people don't

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -152,7 +152,7 @@ pipeline {
                                 publishCsmRpms(
                                         arch: "${ARCH}",
                                         isStable: isStable,
-                                        component: "python${PYTHON_VERSION}-${env.NAME}",
+                                        component: env.NAME,
                                         os: "sle-${sles_major}sp${sles_minor}",
                                         pattern: "dist/rpmbuild/RPMS/${ARCH}/*.rpm",
                                 )

--- a/README.adoc
+++ b/README.adoc
@@ -108,6 +108,41 @@ For more information regarding VCS versioning and dependency managment, see the 
 - https://setuptools.pypa.io/en/latest/userguide/dependency_management.html[Setuptools Dependency Management]
 - pip's documentation on https://pip.pypa.io/en/latest/topics/vcs-support/[VCS support]
 
+==== Using the `libcsm` OS Package
+
+libCSM is offered as an OS package (an `rpm`), this package installs libCSM and its dependencies into
+a virtual environment on the system. The package will depend on a flavor of the `python-base` package
+respective to the distribution being used.
+
+.Note at this time the `rpm` is only available to internal HPE, it will be available via GitHub releases in the near future.
+. To install and activate the virtualenv:
++
+[source,bash]
+----
+SLES_VERSION=$(awk -F= '/VERSION_ID/{gsub(/["]/,"");printf($NF)}' /etc/os-release)
+SLES_MAJOR=$(echo -n $SLES_VERSION | awk -F. '{print $1}')
+SLES_MINOR=$(echo -n $SLES_VERSION | awk -F. '{print $NF}')
+zypper --plus-repo=https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-${SLES_MAJOR}sp${SLES_MINOR}/ --no-gpg-checks in libcsm
+----
+. Then use `libcsm`.
+- Activate the virtual environment
++
+[source,bash]
+----
+source /usr/lib/libcsm/python/bin/activate
+----
+- Use the package ad-hoc in a Python interpreter:
++
+[source,bash]
+----
+/usr/lib/libcsm/python/bin/python
+----
++
+[source,python]
+----
+import libcsm
+----
+
 ===== Importing `libcsm` with a `pyproject.toml` or `setup.py` file
 
 For `setup.py` files, the GitHub source can be included in another project by adding a `dependency_links=[]` parameter in the `setup()` function call.


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2076

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

This change brings in a few enhancements to the repository, and some fundamental changes to the Python Environment:

- Addition of new promotion workflows that automatically create releases on GitHub for every tag. See [Promotion workflows](#promotion-workflows)
- Changing the RPM packaging from depending on PyPi packages from the OS package manager to instead using a `virtualenv` and managing its dependencies in an isolated manner. See [`virtualenv` change](#virtualenv-change)

##### Promotion workflows

When a prerelease or release tag is pushed to the repository, a new GitHub Prerelease or Release is created.

When a new Prerelease is created, it will be marked as a prerelease.
When a new Release is created, it will be marked as the _latest_ release.

In the future we can add logic for including the RPM assets in the release, for now I am working that logic out in another repository.

##### `virtualenv` change

This change switches libCSM to use a virtualenv, and in doing so it enables us to write Python code using non-native Python modules. Prior to this change, we were limited to the very small set of Python modules SUSE shipped in their Python3.9 and Python3.10 repositories. This change enables us to use any PyPi package (e.g. `python310-kubernetes` does not exist, so we can not use code that requires `import kubernetes`).

This new virtualenv environment will still depend on the base system installation of Python, respective to the Python version available in that distro.

Due to the fact that libCSM will no longer be using the OS package management for its dependencies, the name of the package has now changed.
- `python39-libcsm` is now `libcsm`, and still only published to 15SP3 repos
- `python310-libcsm` is now `libcsm`, and still only published to 15SP4 repos

Despite converging to the same name, each package will still require `python39-base` or `python310-base` to be installed. This is determined by which repository `libcsm` was pulled from. The SP3 libCSM will require `python39-base`, and the SP4 libCSM will require `python310-base`. This will scale for future distros, as we continue to build for their latest Python. For example below shows installing the SP3 version on an SP4 system where python39-base is not available will fail:
```bash
redbull-pit:~ # rpm -q python310-base
python310-base-3.10.8-150400.4.15.1.x86_64
redbull-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/libcsm/noarch/libcsm-0.0.3.dev2%2Bgfb2c70d-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp3/libcsm/noarch/libcsm-0.0.3.dev2%2Bgfb2c70d-1.noarch.rpm
error: Failed dependencies:
        python39-base is needed by libcsm-0.0.3.dev2+gfb2c70d-1.noarch
redbull-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/libcsm/noarch/libcsm-0.0.3.dev2%2Bgfb2c70d-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/libcsm/noarch/libcsm-0.0.3.dev2%2Bgfb2c70d-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:libcsm-0.0.3.dev2+gfb2c70d-1     ################################# [100%]
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
