### PR TITLE
Ensure the deprecated package is uninstalled

### DIFF
--- a/libcsm.spec
+++ b/libcsm.spec
@@ -61,10 +61,11 @@ Cray System Management procedures and operations.
 %install
 
 # Install setuptools_scm[toml] so any context in this RPM build can resolve the module version.
-%python_exec -m virtualenv --no-periodic-update --no-setuptools --no-pip --no-wheel %{buildroot}%{install_python_dir}
+%python_exec -m virtualenv --no-periodic-update --no-setuptools --no-wheel %{buildroot}%{install_python_dir}
 
 # Build a source distribution.
-%python_exec -m pip install --disable-pip-version-check --no-cache --root=%{buildroot}%{install_python_dir}  ./dist/*.whl
+%{buildroot}%{install_python_dir}/bin/python -m pip install --disable-pip-version-check --no-cache ./dist/*.whl
+%{buildroot}%{install_python_dir}/bin/python -m pip uninstall -y pip
 
 # Fix the virtualenv activation script, ensure VIRTUAL_ENV points to the installed location on the system.
 sed -i -E 's:^(VIRTUAL_ENV=).*:\1'%{install_python_dir}':' %{buildroot}%{install_python_dir}/bin/activate

--- a/libcsm.spec
+++ b/libcsm.spec
@@ -45,6 +45,7 @@ Version: %(echo $VERSION)
 Release: 1
 Source: %{name}-%{version}.tar.bz2
 Vendor: Hewlett Packard Enterprise Development LP
+Obsoletes: %{python_flavor}-%{name}
 
 %description
 A library for providing common functions to


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #19 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
If a system has `pythonXY-libcsm` installed it must be uninstalled. Even though `pythonXY-libcsm` and `libcsm` both `Provides: libcsm` it is possible to still install both packages. This package is so new that that edge case is rare, but it should be addressed.

Example of both packages being installed and present:
```bash
redbull-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/python3.10-libcsm/noarch/python3.10-libcsm-0.0.2-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/python3.10-libcsm/noarch/python3.10-libcsm-0.0.2-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:python3.10-libcsm-0.0.2-1        ################################# [100%]
redbull-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/libcsm/noarch/libcsm-0.0.3-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/libcsm/noarch/libcsm-0.0.3-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:libcsm-0.0.3-1                   ################################# [100%]
redbull-pit:~ # rpm -qa | grep libcsm
libcsm-0.0.3-1.noarch
python3.10-libcsm-0.0.2-1.noarch
```

The change this PR makes will uninstall the respective obsoleted package:
```bash
redbull-pit:~ # rpm -Uvh https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/libcsm/noarch/libcsm-0.0.3.dev2%2Bg181a145-1.noarch.rpm
Retrieving https://artifactory.algol60.net/artifactory/csm-rpms/hpe/unstable/sle-15sp4/libcsm/noarch/libcsm-0.0.3.dev2%2Bg181a145-1.noarch.rpm
Preparing...                          ################################# [100%]
Updating / installing...
   1:libcsm-0.0.3.dev2+g181a145-1     ################################# [ 50%]
Cleaning up / removing...
   2:python3.10-libcsm-0.0.2-1        ################################# [100%]
```
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
