### PR TITLE
Wrong pattern for prerelease

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -2,9 +2,9 @@ name: Promote a build to a release candidate
 on:
   push:
     tags:
-      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+a[0-9]+'
-      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+b[0-9]+'
-      - 'v?[0-9]+.[0-9]+.[0-9]+-[0-9]+rc[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+a[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+b[0-9]+'
+      - 'v?[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
 
 env:
   ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #19 

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The pattern for pre-releases is wrong, and it is matching a hyphen and digits before the `a|b|rc` string.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
