### PR TITLE
Rename virtualenv

### DIFF
--- a/libcsm.spec
+++ b/libcsm.spec
@@ -26,7 +26,7 @@
 %define doc_example_dir %{doc_dir}examples/
 %define install_dir /usr/lib/%(echo $NAME)/
 %define install_shell_dir %{install_dir}sh
-%define install_python_dir %{install_dir}python
+%define install_python_dir %{install_dir}libcsm-venv
 
 # Define which Python flavors python-rpm-macros will use (this can be a list).
 # https://github.com/openSUSE/python-rpm-macros#terminology

--- a/libcsm.spec
+++ b/libcsm.spec
@@ -60,12 +60,14 @@ Cray System Management procedures and operations.
 
 %install
 
-# Install setuptools_scm[toml] so any context in this RPM build can resolve the module version.
-%python_exec -m virtualenv --no-periodic-update --no-setuptools --no-wheel %{buildroot}%{install_python_dir}
+# Create our virtualenv
+%python_exec -m virtualenv --no-periodic-update %{buildroot}%{install_python_dir}
 
 # Build a source distribution.
 %{buildroot}%{install_python_dir}/bin/python -m pip install --disable-pip-version-check --no-cache ./dist/*.whl
-%{buildroot}%{install_python_dir}/bin/python -m pip uninstall -y pip
+
+# Remove build tools
+%{buildroot}%{install_python_dir}/bin/python -m pip uninstall -y pip setuptools wheel
 
 # Fix the virtualenv activation script, ensure VIRTUAL_ENV points to the installed location on the system.
 sed -i -E 's:^(VIRTUAL_ENV=).*:\1'%{install_python_dir}':' %{buildroot}%{install_python_dir}/bin/activate


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The current virtualenv name shos as `python`, this doesn't offer any contextual information.

Using a virtualenv name that matches our app will make the PS1 more clear to a user when they are in our Python environment.


Before:

```bash
(python) ncn-m001:~/rusty #
```

After:

```bash
(libcsm-venv) ncn-m001:~/rusty #
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
