### PR TITLE
Add `os` and `logger` module.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ __pycache__/
 *.egg*
 *.[tn]ox
 **/*coverage*
+*.log
+
 
 # RPM Build items
 FILES

--- a/libcsm/api.py
+++ b/libcsm/api.py
@@ -24,14 +24,13 @@
 """
 Submodule for interacting with CSM API services.
 """
-from urllib.parse import urlencode
-from urllib import request
-
-import base64
 from json import loads
+
+from urllib import request
+from urllib.parse import urlencode
+import base64
 from kubernetes import client
 from kubernetes import config
-
 from urllib3.exceptions import MaxRetryError
 
 SECRET = 'admin-client-auth'
@@ -59,7 +58,6 @@ class Auth:
     """
 
     def __init__(self, **kwargs) -> None:
-
         config.load_kube_config(**kwargs)
         self.core = client.CoreV1Api()
         self._token = None
@@ -107,7 +105,6 @@ class Auth:
     def token(self) -> str:
         """
         The authentication token.
-        :return: The active token.
         """
         return self._token
 

--- a/libcsm/logger.py
+++ b/libcsm/logger.py
@@ -1,0 +1,66 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Logging module.
+"""
+import os.path
+
+import logging
+from logging.handlers import RotatingFileHandler
+
+LOG_PATH = '/var/log/libcsm.log'
+
+
+class Logger(logging.Logger):
+    """
+    Inherits from logging.Logger, configuring custom settings on
+    initialization.
+    """
+
+    def __init__(
+        self,
+        module_name: str,
+        log_level: int = logging.INFO
+    ) -> None:
+        """
+        :param module_name: Pass __name__ here or whatever name you want to
+                            define the Logger as.
+        :param log_level: Level of logging (default: INFO).
+        """
+        super().__init__(module_name, log_level)
+        formatter = logging.Formatter(
+            '%(asctime)s %(levelname)-8s | %(name)-20s | %(message)s'
+        )
+        formatter.datefmt = '%b %d %H:%M:%S'
+        try:
+            os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+            handler = RotatingFileHandler(LOG_PATH)
+        except OSError as error:
+            print(
+                f'Failed to make {os.path.dirname(LOG_PATH)}\n{error}\n'
+                f'writing logs to present working directory.'
+                )
+            handler = RotatingFileHandler(os.path.basename(LOG_PATH))
+        handler.setFormatter(formatter)
+        self.addHandler(handler)

--- a/libcsm/os.py
+++ b/libcsm/os.py
@@ -1,0 +1,187 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Module for handling command line calls.
+
+.. note::
+   The ``_CLI`` object is private, the intended usage is to use
+   ``run_command``.
+
+"""
+from contextlib import contextmanager
+from time import time
+from subprocess import PIPE
+from subprocess import Popen
+import os
+
+from libcsm.logger import Logger
+
+LOG = Logger(__file__)
+
+
+class _CLI:
+    """
+    An object to abstract the return result from ``run_command``.
+
+    """
+    _stdout = ''
+    _stderr = ''
+    _return_code = None
+    _duration = None
+
+    def __init__(self, args: [str, list], shell: bool = False) -> None:
+        """
+        If shell==True then the arguments will be converted to a string if
+        a list was passed.
+        The conversion is recommended by Popen's documentation:
+            https://docs.python.org/3/library/subprocess.html
+
+        :param args: The arguments (as a list or string) to run with Popen.
+        :param shell: Whether to run Popen in a shell (default: False)
+        """
+        if shell and isinstance(args, list):
+            self.args = ' '.join(args)
+        else:
+            self.args = args
+        self.shell = shell
+        self._run()
+
+    def _run(self) -> None:
+        """
+        Run the arguments and set the object's class variables with the
+        results.
+        """
+        start_time = time()
+        try:
+            with Popen(
+                self.args,
+                stdout=PIPE,
+                stderr=PIPE,
+                shell=self.shell,
+            ) as command:
+                stdout, stderr = command.communicate()
+        except IOError as error:
+            self._stderr = error.strerror
+            self._return_code = error.errno
+            LOG.error('Could not find command for given args: %s', self.args)
+        else:
+            self._stdout = stdout.decode('utf8')
+            self._stderr = stderr.decode('utf8')
+            self._return_code = command.returncode
+        self._duration = time() - start_time
+        if self._return_code and self._duration:
+            LOG.info(
+                '%s ran for %f (sec) with return code %i',
+                self.args,
+                self._duration,
+                self._return_code
+            )
+
+    @property
+    def stdout(self) -> str:
+        """
+        ``stdout`` from the command.
+        """
+        return self._stdout
+
+    @property
+    def stderr(self) -> str:
+        """
+        ``stderr`` from the command.
+        """
+        return self._stderr
+
+    @property
+    def return_code(self) -> str:
+        """
+        return code from the command.
+        """
+        return self._return_code
+
+    @property
+    def duration(self) -> float:
+        """
+        The duration of the running command.
+        """
+        return self._duration
+
+
+@contextmanager
+def chdir(directory: str, create: bool = False) -> None:
+    """
+    Changes into a given directory and returns to the original directory on
+    exit.
+
+    .. note::
+       This does not wrap the yield in a 'try', everything done within
+       the else is the user's responsibility.
+
+    .. code-block:: python
+
+        from libcsm.os import chdir
+
+        print('doing things in /dir/foo')
+        with chdir('/some/other/dir'):
+            # doing things in /some/other/dir
+        print('doing more things in /dir/foo')
+
+    :param directory: Where you want to go.
+    :param create: Whether you want the entire tree created or not.
+    """
+    original = os.getcwd()
+    if not os.path.exists(directory) and create:
+        os.makedirs(directory)
+    try:
+        os.chdir(directory)
+    except OSError:
+        LOG.warning('Invalid directory [%s]', directory)
+    else:
+        yield
+    finally:
+        os.chdir(original)
+
+
+def run_command(
+    args: [list, str],
+    in_shell: bool = False,
+    silence: bool = False, ) -> _CLI:
+    """
+    Runs a given command or list of commands by instantiating a ``CLI`` object.
+
+    .. code-block:: python
+
+        from libcsm.os import run_command
+
+        result = run_command(['my', 'args'])
+        print(vars(result))
+
+    :param args: List of arguments to run, can also be a string. If a string,
+    :param in_shell: Whether to use a shell when invoking the command.
+    :param silence: Tells this not to output the command to console.
+    """
+    if not silence:
+        LOG.info(
+            'Running sub-command: %s (in shell: %s)', ' '.join(args), in_shell
+        )
+    return _CLI(args, shell=in_shell)

--- a/libcsm/tests/test_api.py
+++ b/libcsm/tests/test_api.py
@@ -22,18 +22,18 @@
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Tests for the api submodule.
+Tests for the ``api`` submodule.
 """
+from urllib import request
+
 import base64
 import io
-
 from dataclasses import dataclass
-from urllib import request
 import pytest
-
 from kubernetes import client
 from urllib3.exceptions import MaxRetryError
 import mock
+
 from libcsm import api
 
 
@@ -85,7 +85,8 @@ class TestApi:
         Verify our expected errors cause our custom error to be raised.
         """
         auth = api.Auth()
-        auth.core.read_namespaced_secret.side_effect = client.exceptions.ApiException
+        auth.core.read_namespaced_secret.side_effect = \
+            client.exceptions.ApiException
         with pytest.raises(api.AuthException):
             auth.refresh_token()
         auth.core.read_namespaced_secret.side_effect = MaxRetryError(

--- a/libcsm/tests/test_os.py
+++ b/libcsm/tests/test_os.py
@@ -1,0 +1,64 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Tests for the ``cmd`` module.
+"""
+from os import getcwd
+
+from libcsm.os import run_command
+from libcsm.os import chdir
+
+
+class TestCLI:
+    """
+    Test class for the ``cli`` module.
+    """
+
+    def test_run_command(self) -> None:
+        """
+        Assert that we can run a command and that if it isn't found an
+        error is raised.
+        """
+        command = ['ls', '-l']
+        shell_command = 'ls -l'
+        bad_command = 'foo!!!'
+        no_shell_result = run_command(shell_command)
+        shell_result = run_command(shell_command, in_shell=True)
+        bad_result = run_command(bad_command)
+        command_result = run_command(command)
+        for result in [no_shell_result, shell_result, bad_result,
+                       command_result]:
+            assert result.duration > 0.0
+            assert isinstance(result.return_code, int)
+            assert result.stdout or result.stderr
+
+    def test_chdir(self) -> None:
+        """
+        Assert that our context manager will change directories and
+        change back to our original directory.
+        """
+        original = getcwd()
+        with chdir('/'):
+            assert getcwd() == '/'
+        assert getcwd() == original

--- a/libcsm/tests/test_os.py
+++ b/libcsm/tests/test_os.py
@@ -22,7 +22,7 @@
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Tests for the ``cmd`` module.
+Tests for the ``os`` module.
 """
 from os import getcwd
 
@@ -32,7 +32,7 @@ from libcsm.os import chdir
 
 class TestCLI:
     """
-    Test class for the ``cli`` module.
+    Test class for the ``os`` module.
     """
 
     def test_run_command(self) -> None:


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->


#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The new `os` module provides two things:

1. New `run_command` method that wraps `Popen`, facilitating consistent shell calls throughout `libCSM`. `run_command` returns an object that has the `stdout`, `stderr`, `exit_code` (a.k.a. `return_code`), and duration for the given command(s).

   ```python
   from libcsm.os import run_command

   result = run_command(['my', 'args'])
   print(vars(result))
   ```

1. New `chdir` context manager, allowing users to change into a directory and then automatically exit that directory when their done.

   ```python
   from libcsm.os import chdir

   print('doing things in /dir/foo')
   with chdir('/some/other/dir'):
      # doing things in /some/other/dir
   print('doing more things in /dir/foo')
   ```

Lastly this adds a very basic `logger` module to log to file.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required).
- [x] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
