### PR TITLE
`int` not `str`

### DIFF
--- a/libcsm/os.py
+++ b/libcsm/os.py
@@ -113,7 +113,7 @@ class _CLI:
         return self._stderr
 
     @property
-    def return_code(self) -> str:
+    def return_code(self) -> int:
         """
         return code from the command.
         """


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: #38 

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request
- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->
Using `_CLI.return_code` was causing lint errors when I expected it to be an `int`. This is an `int`, and should not be a `str`.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
