### PR TITLE
Allow `int` commandline parameters

### DIFF
--- a/libcsm/os.py
+++ b/libcsm/os.py
@@ -180,8 +180,11 @@ def run_command(
     :param in_shell: Whether to use a shell when invoking the command.
     :param silence: Tells this not to output the command to console.
     """
+    args_string = [str(x) for x in args]
     if not silence:
         LOG.info(
-            'Running sub-command: %s (in shell: %s)', ' '.join(args), in_shell
+            'Running sub-command: %s (in shell: %s)',
+            ' '.join(args_string),
+            in_shell
         )
-    return _CLI(args, shell=in_shell)
+    return _CLI(args_string, shell=in_shell)


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: `TypeError` on `run_command` when non-strings are passed

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `run_command` function fails `args`'s elements aren't all `str`.

In order to support `int` arguments the elements must be casted to a `str`.

An example of the same `os.py` file in another package I'm working on, the first two lines print what's in `args` before a `TypeError` is thrown.
```bash
hypervisor:/usr/lib/crucible/lib/python3.10/site-packages/crucible/scripts # crucible install
['/usr/lib/crucible/lib64/python3.10/site-packages/crucible/scripts/install.sh', '-d', 2, '-s', 25, '-l', 'mirror']
/usr/lib/crucible/lib64/python3.10/site-packages/crucible/scripts/install.sh -d 2 -s 25 -l mirror
Traceback (most recent call last):
  File "/usr/bin/crucible", line 8, in <module>
    sys.exit(crucible())
  File "/usr/lib/crucible/lib64/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/crucible/lib64/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/crucible/cli.py", line 231, in install
    install_to_disk(**kwargs)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/crucible/install.py", line 71, in install_to_disk
    result = run_command(
  File "/usr/lib/crucible/lib64/python3.10/site-packages/crucible/os.py", line 190, in run_command
    return _CLI(args, shell=in_shell)
  File "/usr/lib/crucible/lib64/python3.10/site-packages/crucible/os.py", line 68, in __init__
    self._run()
  File "/usr/lib/crucible/lib64/python3.10/site-packages/crucible/os.py", line 77, in _run
    with Popen(
  File "/usr/lib64/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.10/subprocess.py", line 1780, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
TypeError: expected str, bytes or os.PathLike object, not int
```

After applying this patch the `TypeError` was avoided.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
