### PR TITLE
CASMPET-6566 add function to get hostname from xname

### DIFF
--- a/entry_points.ini
+++ b/entry_points.ini
@@ -39,6 +39,6 @@
 #     https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-syntax
 #
 [console_scripts]
-set-image-in-bss = libcsm.bss.set_image:main
-get-xname = libcsm.sls.get_xname:main
-get-hostname = libcsm.sls.get_hostname:main
+bss-set-image = libcsm.bss.set_image:main
+sls-get-xname = libcsm.sls.get_xname:main
+sls-get-hostname = libcsm.sls.get_hostname:main

--- a/entry_points.ini
+++ b/entry_points.ini
@@ -41,3 +41,4 @@
 [console_scripts]
 set-image-in-bss = libcsm.bss.set_image:main
 get-xname = libcsm.sls.get_xname:main
+get-hostname = libcsm.sls.get_hostname:main

--- a/libcsm/sls/api.py
+++ b/libcsm/sls/api.py
@@ -86,7 +86,7 @@ class API:
         
         for node in components_response.json():
             try:
-                if xname is node['Xname']:
+                if xname == node['Xname']:
                     # assumes the hostname is the first entry in ['ExtraProperties']['Aliases']
                     return node['ExtraProperties']['Aliases'][0]
             except KeyError as error:

--- a/libcsm/sls/api.py
+++ b/libcsm/sls/api.py
@@ -63,7 +63,7 @@ class API:
 
         return components_response
 
-    def get_xname(self, hostname: str):
+    def get_xname(self, hostname: str) -> str:
         """
         Function to get the xname of a node from SLS based on a provided hostname.
         """
@@ -77,3 +77,19 @@ class API:
                 raise KeyError(f'ERROR [ExtraProperties][Aliases] was not in the response from sls. \
                 These fields are expected in the json response. The resonponse was {components_response.json()}') from error
         raise Exception(f'ERROR hostname:{hostname} was not found in management nodes.')
+
+    def get_hostname(self, xname: str) -> str:
+        """
+        Function to get the hostname of a management node from SLS based on a provided xname.
+        """
+        components_response = self.get_management_components_from_sls()
+        
+        for node in components_response.json():
+            try:
+                if xname is node['Xname']:
+                    # assumes the hostname is the first entry in ['ExtraProperties']['Aliases']
+                    return node['ExtraProperties']['Aliases'][0]
+            except KeyError as error:
+                raise KeyError(f'ERROR [ExtraProperties][Aliases] was not in the response from sls. \
+                These fields are expected in the json response. The resonponse was {components_response.json()}') from error
+        raise Exception(f'ERROR xname:{xname} was not found in management nodes.')

--- a/libcsm/sls/get_hostname.py
+++ b/libcsm/sls/get_hostname.py
@@ -1,0 +1,44 @@
+#
+#  MIT License
+#
+#  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+Function for setting boot-image in BSS
+"""
+
+import sys
+import click
+from libcsm.sls import api
+
+@click.command()
+@click.option('--xname', required=True, type=str, help='xname of the node whose hostname should be returned.')
+@click.option('--api_gateway_address', required=False, type=str, default='api-gw-service-nmn.local')
+def main(xname, api_gateway_address):
+
+    """Get the hostname of a NCN given an Xname. This queries SLS for management nodes' information."""
+
+    sls_api = api.API(api_gateway_address)
+    try:
+        print(sls_api.get_hostname(xname))
+    except Exception as error:
+        print(f'{error}')
+        sys.exit(1)

--- a/libcsm/tests/sls/test_api.py
+++ b/libcsm/tests/sls/test_api.py
@@ -112,7 +112,7 @@ class TestSLSApi:
                 with pytest.raises(Exception):
                     sls_api.get_xname('ncn-BAD')
 
-    def test_get_xname_invalid_resonse(self, *_) -> None:
+    def test_get_xname_invalid_response(self, *_) -> None:
         """
         Tests the SLS get_xname function given bad hostname.
         """
@@ -127,3 +127,52 @@ class TestSLSApi:
             with mock.patch.object(sls_api, 'get_management_components_from_sls', return_value=mock_sls_response):
                 with pytest.raises(KeyError):
                     sls_api.get_xname('ncn-w001')
+
+    def test_get_hostname(self, *_) -> None:
+        """
+        Tests response from the SLS get_hostname function.
+        """
+        mock_components = [
+                            {'Parent': 'par1', 'Xname': 'xname1',  'ExtraProperties': {'Aliases': ['ncn-w001'], 'A': 100}},
+                            {'Parent': 'par2', 'Xname': 'xname2',  'ExtraProperties': {'Aliases': ['ncn-s002'], 'A': 101}}
+                          ]
+        mock_status = http.HTTPStatus.OK
+        mock_sls_response = MockHTTPResponse(mock_components, mock_status)
+
+        with mock.patch.object(api.Auth, 'refresh_token', return_value=None):
+            sls_api = slsApi.API()
+            with mock.patch.object(sls_api, 'get_management_components_from_sls', return_value=mock_sls_response):
+                ret_hostname = sls_api.get_hostname('xname1')
+                assert ret_hostname == 'ncn-w001'
+
+    def test_get_hostname_bad_xname(self, *_) -> None:
+        """
+        Tests the SLS get_hostname function given bad xname.
+        """
+        mock_components = [
+                            {'Parent': 'par1', 'Xname': 'xname1',  'ExtraProperties': {'Aliases': ['ncn-w001'], 'A': 100}},
+                            {'Parent': 'par2', 'Xname': 'xname2',  'ExtraProperties': {'Aliases': ['ncn-s002'], 'A': 101}}
+                          ]
+        mock_status = http.HTTPStatus.OK
+        mock_sls_response = MockHTTPResponse(mock_components, mock_status)
+        with mock.patch.object(api.Auth, 'refresh_token', return_value=None):
+            sls_api = slsApi.API()
+            with mock.patch.object(sls_api, 'get_management_components_from_sls', return_value=mock_sls_response):
+                with pytest.raises(Exception):
+                    sls_api.get_hostname('badXname')
+
+    def test_get_hostname_invalid_response(self, *_) -> None:
+        """
+        Tests the SLS get_xname function with an invalid response from sls.get_management_components_from_sls.
+        """
+        mock_components = [
+                            {'Parent': 'par1', 'Xname': 'xname1',  'No_extra_properties': {'Aliases': ['ncn-w001'], 'A': 100}},
+                            {'Parent': 'par2', 'Xname': 'xname2',  'No_extra_properties': {'Aliases': ['ncn-s002'], 'A': 101}}
+                          ]
+        mock_status = http.HTTPStatus.OK
+        mock_sls_response = MockHTTPResponse(mock_components, mock_status)
+        with mock.patch.object(api.Auth, 'refresh_token', return_value=None):
+            sls_api = slsApi.API()
+            with mock.patch.object(sls_api, 'get_management_components_from_sls', return_value=mock_sls_response):
+                with pytest.raises(KeyError):
+                    sls_api.get_hostname('xname2')

--- a/libcsm/tests/sls/test_get_hostname.py
+++ b/libcsm/tests/sls/test_get_hostname.py
@@ -27,7 +27,7 @@ Tests for the sls get_hostname function.
 
 import http
 import mock
-import click
+
 from click.testing import CliRunner
 from libcsm.sls import get_hostname
 

--- a/libcsm/tests/sls/test_get_hostname.py
+++ b/libcsm/tests/sls/test_get_hostname.py
@@ -22,14 +22,14 @@
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
 """
-Tests for the sls get_xnames function.
+Tests for the sls get_hostname function.
 """
 
 import http
 import mock
-
+import click
 from click.testing import CliRunner
-from libcsm.sls import get_xname
+from libcsm.sls import get_hostname
 
 class MockHTTPResponse:
     def __init__(self, data, status_code):
@@ -40,13 +40,13 @@ class MockHTTPResponse:
         return self.json_data
 
 @mock.patch('kubernetes.config.load_kube_config')
-class TestGetXname:
+class TestGetHostname:
 
     @mock.patch('libcsm.api.Auth', spec=True)
     @mock.patch('libcsm.sls.api.API.get_management_components_from_sls', spec=True)
-    def test_get_management_components_from_sls(self, mock_management_components, *_) -> None:
+    def test_get_hostname(self, mock_management_components, *_) -> None:
         """
-        Tests successful run of get_xname main function.
+        Tests successful run of get_hostname main function.
         """
         mock_components = [
                             {'Parent': 'par1', 'Xname': 'xname1',  'ExtraProperties': {'Aliases': ['ncn-w001'], 'A': 100}},
@@ -56,14 +56,14 @@ class TestGetXname:
         mock_sls_response = MockHTTPResponse(mock_components, mock_status)
         mock_management_components.return_value = mock_sls_response
         cli_runner = CliRunner()
-        result = cli_runner.invoke(get_xname.main, ["--hostname", "ncn-w001"])
+        result = cli_runner.invoke(get_hostname.main, ["--xname", "xname1"])
         assert result.exit_code == 0
 
     @mock.patch('libcsm.api.Auth', spec=True)
     @mock.patch('libcsm.sls.api.API.get_management_components_from_sls', spec=True)
-    def test_get_management_components_from_sls_error(self, mock_management_components, *_) -> None:
+    def test_get_hostname_bad_xname(self, mock_management_components, *_) -> None:
         """
-        Tests unsuccessful run of get_xname main function.
+        Tests unsuccessful run of get_hostname main function.
         """
         mock_components = [
                             {'Parent': 'par1', 'Xname': 'xname1',  'ExtraProperties': {'Aliases': ['ncn-w001'], 'A': 100}},
@@ -73,5 +73,5 @@ class TestGetXname:
         mock_sls_response = MockHTTPResponse(mock_components, mock_status)
         mock_management_components.return_value = mock_sls_response
         cli_runner = CliRunner()
-        result = cli_runner.invoke(get_xname.main, ["--hostname", "bad-hostname"])
+        result = cli_runner.invoke(get_hostname.main, ["--xname", "bad-xname"])
         assert result.exit_code == 1


### PR DESCRIPTION
### Summary and Scope
Adds function to get hostname from xname. On the CLI, user can input "get-hostname --xname <xname>" and get a nodes hostname.
<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->


#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- RFE Pull Request - CASMPET-6566

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [x] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
