### PR TITLE
`^VIRTUAL_ENV` is no longer used; fix virtualenv, and command line callables

### DIFF
--- a/libcsm.spec
+++ b/libcsm.spec
@@ -70,7 +70,7 @@ Cray System Management procedures and operations.
 %{buildroot}%{install_python_dir}/bin/python -m pip uninstall -y pip setuptools wheel
 
 # Fix the virtualenv activation script, ensure VIRTUAL_ENV points to the installed location on the system.
-sed -i -E 's:^(VIRTUAL_ENV=).*:\1'%{install_python_dir}':' %{buildroot}%{install_python_dir}/bin/activate
+find %{buildroot}%{install_python_dir}/bin -type f | xargs -t -i sed -i 's:%{buildroot}%{install_python_dir}:%{install_python_dir}:g' {}
 
 install -d -m 755 %{buildroot}%{doc_example_dir}
 cp -pvr ./examples/* %{buildroot}%{doc_example_dir} | awk '{print $3}' | sed "s/'//g" | sed "s|$RPM_BUILD_ROOT||g" | tee -a INSTALLED_FILES


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: Run commands

#### Issue Type

<!--- Delete un-needed bullets; choose one or more.  -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `VIRTUAL_ENV` value is no longer set the same way in the `activate` scripts. Use a more generalized method for modifying the path. The previous method the `.spec` was using no longer works, I could not find out why. Likely due to a change in some Python build tool.

Currently all the paths look like this, and running a command (see bottom of snippet) fails to load the virtualenv:
```bash
ncn-m001:/usr/lib/libcsm/libcsm-venv/bin # grep libcsm-venv *
activate:VIRTUAL_ENV=/usr/lib/libcsm/libcsm-venv
activate.csh:setenv VIRTUAL_ENV '/home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv'
activate.fish:set -gx VIRTUAL_ENV '/home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv'
activate.nu:    let virtual_env = '/home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv'
bss-set-image:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
jp.py:#!/home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python
normalizer:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
grep: __pycache__: Is a directory
pyrsa-decrypt:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
pyrsa-encrypt:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
pyrsa-keygen:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
pyrsa-priv2pub:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
pyrsa-sign:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
pyrsa-verify:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
sls-get-hostname:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
sls-get-xname:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
wsdump:'''exec' /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python "$0" "$@"
ncn-m001:/usr/lib/libcsm/libcsm-venv/bin # ./bss-set-image
./bss-set-image: line 2: /home/jenkins/workspace/Cray-HPE_libCSM_v0.0.5rc1/dist/rpmbuild/noarch/3.10/BUILDROOT/libcsm-0.0.5rc1-1.noarch/usr/lib/libcsm/libcsm-venv/bin/python: No such file or directory
```

After this fix, all the paths are correct and running a command loads the virtualenv correctly.
```bash
38dfec249ad3:/usr/lib/libcsm/libcsm-venv/bin # grep libcsm-venv *
grep: __pycache__: Is a directory
activate:VIRTUAL_ENV='/usr/lib/libcsm/libcsm-venv'
activate.csh:setenv VIRTUAL_ENV '/usr/lib/libcsm/libcsm-venv'
activate.fish:set -gx VIRTUAL_ENV '/usr/lib/libcsm/libcsm-venv'
activate.nu:    let virtual_env = '/usr/lib/libcsm/libcsm-venv'
bss-set-image:#!/usr/lib/libcsm/libcsm-venv/bin/python
jp.py:#!/usr/lib/libcsm/libcsm-venv/bin/python
normalizer:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-decrypt:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-encrypt:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-keygen:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-priv2pub:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-sign:#!/usr/lib/libcsm/libcsm-venv/bin/python
pyrsa-verify:#!/usr/lib/libcsm/libcsm-venv/bin/python
sls-get-hostname:#!/usr/lib/libcsm/libcsm-venv/bin/python
sls-get-xname:#!/usr/lib/libcsm/libcsm-venv/bin/python
wsdump:#!/usr/lib/libcsm/libcsm-venv/bin/python
38dfec249ad3:/build/libCSM # /usr/lib/libcsm/libcsm-venv/bin/bss-set-image
Usage: bss-set-image [OPTIONS]
Try 'bss-set-image --help' for help.

Error: Missing option '--image-id'.
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required).
- [ ] I have added unit tests for my code.
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
