### PR TITLE
Fix docs version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,11 @@ jobs:
       - uses: actions/setup-python@v3
       - name: Install dependencies
         run: |
-          pip install .[ci]
+          pip install setuptools_scm[toml]
+          pip install .[docs]
       - name: Sphinx build
         run: |
-          nox -e docs
+          make docs
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/docs/libcsm.api.rst
+++ b/docs/libcsm.api.rst
@@ -1,8 +1,7 @@
-libcsm.api module
-=================
+``libcsm.api`` module
+=====================
 
 .. automodule:: libcsm.api
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.bss.api.rst
+++ b/docs/libcsm.bss.api.rst
@@ -1,5 +1,5 @@
-libcsm.bss.api module
-=====================
+``libcsm.bss.api`` module
+=========================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.bss.rst
+++ b/docs/libcsm.bss.rst
@@ -1,5 +1,5 @@
-libcsm.bss package
-==================
+``libcsm.bss`` package
+======================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.bss.set_image.rst
+++ b/docs/libcsm.bss.set_image.rst
@@ -1,5 +1,5 @@
-libcsm.bss.set_image module
-===========================
+``libcsm.bss.set_image`` module
+===============================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.hsm.components.rst
+++ b/docs/libcsm.hsm.components.rst
@@ -1,5 +1,5 @@
-libcsm.hsm.components module
-============================
+``libcsm.hsm.components`` module
+================================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.hsm.rst
+++ b/docs/libcsm.hsm.rst
@@ -1,5 +1,5 @@
-libcsm.hsm package
-==================
+``libcsm.hsm`` package
+======================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.hsm.xnames.rst
+++ b/docs/libcsm.hsm.xnames.rst
@@ -1,5 +1,5 @@
-libcsm.hsm.xnames module
-========================
+``libcsm.hsm.xnames`` module
+============================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.logger.rst
+++ b/docs/libcsm.logger.rst
@@ -1,8 +1,7 @@
-libcsm.logger module
-====================
+``libcsm.logger`` module
+========================
 
 .. automodule:: libcsm.logger
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.os.rst
+++ b/docs/libcsm.os.rst
@@ -1,8 +1,7 @@
-libcsm.os module
-================
+``libcsm.os`` module
+====================
 
 .. automodule:: libcsm.os
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.requests.rst
+++ b/docs/libcsm.requests.rst
@@ -1,5 +1,5 @@
-libcsm.requests package
-=======================
+``libcsm.requests`` package
+===========================
 
 Submodules
 ----------
@@ -16,5 +16,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-
-

--- a/docs/libcsm.requests.session.rst
+++ b/docs/libcsm.requests.session.rst
@@ -1,5 +1,5 @@
-libcsm.requests.session module
-==============================
+``libcsm.requests.session`` module
+==================================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.rst
+++ b/docs/libcsm.rst
@@ -1,5 +1,5 @@
-libcsm package
-==============
+``libcsm`` package
+==================
 
 Subpackages
 -----------
@@ -31,4 +31,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.s3.images.rst
+++ b/docs/libcsm.s3.images.rst
@@ -1,5 +1,5 @@
-libcsm.s3.images module
-=======================
+``libcsm.s3.images`` module
+===========================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.s3.rst
+++ b/docs/libcsm.s3.rst
@@ -1,5 +1,5 @@
-libcsm.s3 package
-=================
+``libcsm.s3`` package
+=====================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.s3.s3object.rst
+++ b/docs/libcsm.s3.s3object.rst
@@ -1,5 +1,5 @@
-libcsm.s3.s3object module
-=========================
+``libcsm.s3.s3object`` module
+=============================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.sls.api.rst
+++ b/docs/libcsm.sls.api.rst
@@ -1,5 +1,5 @@
-libcsm.sls.api module
-=====================
+``libcsm.sls.api`` module
+=========================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.sls.get_hostname.rst
+++ b/docs/libcsm.sls.get_hostname.rst
@@ -1,5 +1,5 @@
-libcsm.sls.get_hostname module
-==============================
+``libcsm.sls.get_hostname`` module
+==================================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.sls.get_xname.rst
+++ b/docs/libcsm.sls.get_xname.rst
@@ -1,5 +1,5 @@
-libcsm.sls.get_xname module
-===========================
+``libcsm.sls.get_xname`` module
+===============================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.sls.rst
+++ b/docs/libcsm.sls.rst
@@ -1,5 +1,5 @@
-libcsm.sls package
-==================
+``libcsm.sls`` package
+======================
 
 Submodules
 ----------
@@ -18,4 +18,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.bss.rst
+++ b/docs/libcsm.tests.bss.rst
@@ -1,5 +1,5 @@
-libcsm.tests.bss package
-========================
+``libcsm.tests.bss`` package
+============================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.bss.test_api.rst
+++ b/docs/libcsm.tests.bss.test_api.rst
@@ -1,6 +1,5 @@
-libcsm.tests.bss.test_api module
-================================
-
+``libcsm.tests.bss.test_api`` module
+====================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.bss.test_set_image.rst
+++ b/docs/libcsm.tests.bss.test_set_image.rst
@@ -1,6 +1,5 @@
-libcsm.tests.bss.test_set_image module
-======================================
-
+``libcsm.tests.bss.test_set_image`` module
+==========================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.hsm.rst
+++ b/docs/libcsm.tests.hsm.rst
@@ -1,5 +1,5 @@
-libcsm.tests.hsm package
-========================
+``libcsm.tests.hsm`` package
+============================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.hsm.test_api.rst
+++ b/docs/libcsm.tests.hsm.test_api.rst
@@ -1,6 +1,5 @@
-libcsm.tests.hsm.test_api module
-================================
-
+``libcsm.tests.hsm.test_api`` module
+====================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.hsm.test_xnames.rst
+++ b/docs/libcsm.tests.hsm.test_xnames.rst
@@ -1,6 +1,5 @@
-libcsm.tests.hsm.test_xnames module
-===================================
-
+``libcsm.tests.hsm.test_xnames`` module
+=======================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.mock_objects.mock_http.rst
+++ b/docs/libcsm.tests.mock_objects.mock_http.rst
@@ -1,6 +1,5 @@
-libcsm.tests.mock_objects.mock_http module
-==========================================
-
+``libcsm.tests.mock_objects.mock_http`` module
+==============================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.mock_objects.mock_sls.rst
+++ b/docs/libcsm.tests.mock_objects.mock_sls.rst
@@ -1,6 +1,5 @@
-libcsm.tests.mock_objects.mock_sls module
-=========================================
-
+``libcsm.tests.mock_objects.mock_sls`` module
+=============================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.mock_objects.rst
+++ b/docs/libcsm.tests.mock_objects.rst
@@ -1,5 +1,5 @@
-libcsm.tests.mock_objects package
-=================================
+``libcsm.tests.mock_objects`` package
+=====================================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.rst
+++ b/docs/libcsm.tests.rst
@@ -1,5 +1,5 @@
-libcsm.tests package
-====================
+``libcsm.tests`` package
+========================
 
 Subpackages
 -----------
@@ -29,4 +29,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.s3.rst
+++ b/docs/libcsm.tests.s3.rst
@@ -1,5 +1,5 @@
-libcsm.tests.s3 package
-=======================
+``libcsm.tests.s3`` package
+===========================
 
 Submodules
 ----------
@@ -17,4 +17,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.s3.test_get_s3_image_info.rst
+++ b/docs/libcsm.tests.s3.test_get_s3_image_info.rst
@@ -1,6 +1,5 @@
-libcsm.tests.s3.test_get_s3_image_info module
-=============================================
-
+``libcsm.tests.s3.test_get_s3_image_info`` module
+=================================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.s3.test_s3object.rst
+++ b/docs/libcsm.tests.s3.test_s3object.rst
@@ -1,6 +1,5 @@
-libcsm.tests.s3.test_s3object module
-=====================================
-
+``libcsm.tests.s3.test_s3object`` module
+=========================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.sls.rst
+++ b/docs/libcsm.tests.sls.rst
@@ -1,5 +1,5 @@
-libcsm.tests.sls package
-========================
+``libcsm.tests.sls`` package
+============================
 
 Submodules
 ----------
@@ -18,4 +18,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.sls.test_api.rst
+++ b/docs/libcsm.tests.sls.test_api.rst
@@ -1,6 +1,5 @@
-libcsm.tests.sls.test_api module
-================================
-
+``libcsm.tests.sls.test_api`` module
+====================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.sls.test_get_hostname.rst
+++ b/docs/libcsm.tests.sls.test_get_hostname.rst
@@ -1,6 +1,5 @@
-libcsm.tests.sls.test_get_hostname module
-=========================================
-
+``libcsm.tests.sls.test_get_hostname`` module
+=============================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.sls.test_get_xname.rst
+++ b/docs/libcsm.tests.sls.test_get_xname.rst
@@ -1,6 +1,5 @@
-libcsm.tests.sls.test_get_xname module
-======================================
-
+``libcsm.tests.sls.test_get_xname`` module
+==========================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.test_api.rst
+++ b/docs/libcsm.tests.test_api.rst
@@ -1,6 +1,5 @@
-libcsm.tests.test_api module
-============================
-
+``libcsm.tests.test_api`` module
+================================
 
 Module contents
 ---------------
@@ -9,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/libcsm.tests.test_os.rst
+++ b/docs/libcsm.tests.test_os.rst
@@ -1,5 +1,5 @@
-libcsm.tests.test_os module
-===========================
+``libcsm.tests.test_os`` module
+===============================
 
 Module contents
 ---------------
@@ -8,4 +8,3 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
-


### PR DESCRIPTION
Minor adjustments.

Version shows incorrectly after merging, it showed correctly for local doc builds. I forgot that when using setuptools_scm, one must also install setuptools_scm in the environment running sphinx.
![image](https://github.com/Cray-HPE/libCSM/assets/7772179/16441708-3f1d-4d2d-ae04-9ff47e81e02d)

Also fixes some trivial extra newlines, and makes the headers monospaced when referring to packages or modules.